### PR TITLE
Reduces the incidence of roundstart chemist deathmatches

### DIFF
--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -31,7 +31,7 @@ Ship Engineer=5,5
 Atmospheric Technician=3,2
 
 Medical Doctor=5,3
-Chemist=2,2
+Chemist=1,1
 Geneticist=2,2
 Virologist=1,1
 

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -43,4 +43,4 @@ Detective=1,1
 Security Officer=5,5
 
 AI=0,1
--Cyborg=0,1
+Cyborg=0,1

--- a/config/jobs.txt
+++ b/config/jobs.txt
@@ -43,4 +43,4 @@ Detective=1,1
 Security Officer=5,5
 
 AI=0,1
-Cyborg=0,1
+-Cyborg=0,1


### PR DESCRIPTION
The ship starts with two chemists, but only has the infrastructure to support one. 

:cl: 
tweak: Lowers the number of chemist positions to one.
/:cl:
